### PR TITLE
Fix: Remove unused variable linting rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,15 +26,6 @@
       "rules": {
         "@typescript-eslint/no-unused-vars": "off",
         "unused-imports/no-unused-imports": "error",
-        "unused-imports/no-unused-vars": [
-          "error",
-          {
-            "vars": "all",
-            "varsIgnorePattern": "^_",
-            "args": "after-used",
-            "argsIgnorePattern": "^_"
-          }
-        ],
         "no-restricted-imports": [
           "error",
           {


### PR DESCRIPTION
This commit removes the `unused-imports/no-unused-vars` ESLint rule, which was causing issues. The `unused-imports/no-unused-imports` rule and the `unused-imports` plugin are kept to continue checking for unused imports.